### PR TITLE
removing `co` from examples for callbacks

### DIFF
--- a/docs/beginner/callbacks.md
+++ b/docs/beginner/callbacks.md
@@ -6,7 +6,6 @@ Using `.run()`, plain callbacks can be used to control Nightmare:
 
 ```js
 var Nightmare = require('nightmare'),
-  co = require('co'),
   nightmare = Nightmare({
     show: true
   });

--- a/examples/beginner/callbacks/basic.js
+++ b/examples/beginner/callbacks/basic.js
@@ -1,5 +1,4 @@
 var Nightmare = require('nightmare'),
-  co = require('co'),
   nightmare = Nightmare({
     show: true
   });


### PR DESCRIPTION
Fixes #7.
