### PR TITLE
language touchups

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Start here if you're new to Nightmare.
 - [`then...catch`](https://github.com/rosshinkley/nightmare-examples/blob/master/docs/known-issues/then-catch.md)
 
 ## Examples
-Simply run `npm install` to install the dependencies.  After that, all of the examples are runnable using `node [example]`.
+Run `npm install` to install the dependencies.  After that, all the examples are runnable using `node [example]`.
 
 ## Additions and Corrections
 If something has been missed, needs correcting, or you have a question, feel free to open an issue or pull request.

--- a/docs/beginner/co.md
+++ b/docs/beginner/co.md
@@ -35,7 +35,7 @@ co(run).then(function(result){
 Nightmare internally (partially) implements promises by exposing `.then()`.  This allows it to be `yield`able for use under `co`.
 
 ## Parameters
-Parameters in `co` are most easily dealt with by using `co.wrap()`.  The following example is the same as above, with the selector for the link `href` passed in.  This also shows how to pass parameters from the parent Nightmare process to the child Electron process through `.evaluate()`:
+Parameters in `co` are passed by using `co.wrap()`.  The following example is the same as above, with the selector for the link `href` passed in.  This also shows how to pass parameters from the parent Nightmare process to the child Electron process through `.evaluate()`:
 
 ```js
 var Nightmare = require('nightmare'),

--- a/docs/beginner/promises.md
+++ b/docs/beginner/promises.md
@@ -23,7 +23,7 @@ nightmare
 ```
 
 ## Running multiple steps
-Promises are useful for chaining multiple steps together using `.then()`.  Say we wanted to modify the Yahoo example to get the first link from the first _and_ second result page:
+Promises are useful for chaining multiple steps together using `.then()`.  Say we wanted to change the Yahoo example to get the first link from the first _and_ second result page:
 
 ```js
 var Nightmare = require('nightmare'),

--- a/docs/known-issues/then-catch.md
+++ b/docs/known-issues/then-catch.md
@@ -1,5 +1,5 @@
 # `then...catch`
-The internal `.then()` method to Nightmare does not work precisely like native Promise `.then()`, instead _always_ opting to take the success and rejection callback for the promise.  This was probably done in an effort to ensure `vo`, `co`, and possibly `mocha-generators` would work nicely with Nightmare.
+The internal `.then()` method to Nightmare does not work precisely like native Promise `.then()`, instead _always_ opting to take the success and rejection callback for the promise.  This was probably done to make sure `vo`, `co`, and possibly `mocha-generators` would work nicely with Nightmare.
 
 The side effect of this is minor, causing exceptions internal to `.then()` to behave differently to their Promise counterparts.  Consider: 
 
@@ -18,7 +18,7 @@ nightmare
     console.log('second argument error');
   });
 ```
-In an ordinary promise, the rejection argument would not get called.  However, in Nightmare, it does.
+In an ordinary promise, the rejection argument would not get called, yet in Nightmare, it does.
 
 ## Solution
 Alter the `.then()` implementation to call `.then(fulfill, reject)` instead of `.then(fulfill).catch(reject)`.  As yet, PR is unsubmitted.

--- a/docs/known-issues/uploads.md
+++ b/docs/known-issues/uploads.md
@@ -1,8 +1,8 @@
 # Uploads with Nightmare
-When presented with a `<input type='file'>`, being able to add files to it in some way would be handy, either directly or via overriding the file selection dialog (similar to `will-download`).
+When presented with a `<input type='file'>`, being able to add files would be useful, either directly or by overriding the file selection dialog (like `will-download`).
 
 ## Solution
-Currently, uploads are not possible with Electron.
+Uploads using `<input type=;file'>` are not possible with Electron.
 
 ## References
 - [Nightmare #235](https://github.com/segmentio/nightmare/issues/235) - Asked after Nightmare v2.x was released and uploads were removed.


### PR DESCRIPTION
Fixes _most_ of #4 except for the "as yet..." in `then-catch.md`.  I left this because I do not think "yet" makes sense in context.
