### PR TITLE
Small typo on a link in Promises.md in the References section

### DIFF
--- a/docs/beginner/promises.md
+++ b/docs/beginner/promises.md
@@ -103,6 +103,6 @@ Note that the Nightmare instance is getting returned.  Again, Nightmare exposes 
 
 ## References
 - [Runnable `Promise` examples](https://github.com/rosshinkley/nightmare-examples/tree/master/examples/beginner/promises)
-- [`then...catch` issues](https://github/com/rosshinkley/nightmare-examples/docs/known-ssues/then-catch.md)
+- [`then...catch` issues](https://github.com/rosshinkley/nightmare-examples/blob/master/docs/known-issues/then-catch.md)
 - [Original Yahoo example](https://github.com/segmentio/nightmare#examples)
 - [MDN Promise documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)


### PR DESCRIPTION
Small typo on a link in Promises.md in the References section